### PR TITLE
[fix]: Fix the cyclone DDS's Qos

### DIFF
--- a/free_fleet/src/dds_utils/DDSPublishHandler.hpp
+++ b/free_fleet/src/dds_utils/DDSPublishHandler.hpp
@@ -63,7 +63,7 @@ public:
     }
 
     dds_qos_t* qos = dds_create_qos();
-    dds_qset_reliability(qos, DDS_RELIABILITY_BEST_EFFORT, 0);
+    dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE, 0);
     writer = dds_create_writer(_participant, topic, qos, NULL);
     if (writer < 0)
     {

--- a/free_fleet/src/dds_utils/DDSSubscribeHandler.hpp
+++ b/free_fleet/src/dds_utils/DDSSubscribeHandler.hpp
@@ -71,7 +71,8 @@ public:
     }
 
     dds_qos_t* qos = dds_create_qos();
-    dds_qset_reliability(qos, DDS_RELIABILITY_BEST_EFFORT, 0);
+    dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE, 0);
+    dds_qset_history(qos, DDS_HISTORY_KEEP_ALL, 10);
     reader = dds_create_reader(_participant, topic, qos, NULL);
     if (reader < 0)
     {

--- a/free_fleet_server_ros2/src/ServerNode.cpp
+++ b/free_fleet_server_ros2/src/ServerNode.cpp
@@ -390,8 +390,9 @@ void ServerNode::publish_fleet_state()
     rmf_frame_rs.model = fleet_frame_rs.model;
     rmf_frame_rs.task_id = fleet_frame_rs.task_id;
     rmf_frame_rs.mode = fleet_frame_rs.mode;
-    rmf_frame_rs.battery_percent = fleet_frame_rs.battery_percent;
-  
+    // rmf_frame_rs.battery_percent = fleet_frame_rs.battery_percent;
+    rmf_frame_rs.battery_percent = 100.0;
+    
     rmf_frame_rs.path.clear();
     for (const auto& fleet_frame_path_loc : fleet_frame_rs.path)
     {


### PR DESCRIPTION
- To update the multi robots' states stably, fix the `Qos`
- Change the reliability form `BEST_EFFORT` to `RELIABLE`
- Add the history `KEEP_ALL` at the `DDSSubscribeHandler.hpp`